### PR TITLE
fixing for R 3.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,13 +7,14 @@ Author: Marc Vaillant
 Maintainer: Brian Caffo <bcaffo@gmail.com>
 Description: Provides an R interface to the MriCloud API.
 License: MIT + file LICENSE
+Encoding: UTF-8
 Depends:
     methods,
 Imports:
     rvest,
     httr,
     objectProperties
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1
 Collate: 
     DtiSegData.r
     T1SegData.r

--- a/R/DtiSegData.r
+++ b/R/DtiSegData.r
@@ -30,5 +30,6 @@ DtiSegData <- setRefClass("DtiSegData",
                               sliceType = "dtiSliceSingleEnum",
                               atlas = "dtiAtlasSingleEnum",
                               description = "character")),
-                          prototype = list(sliceType = dtiSliceType("Axial"),
+                              representation = list(sliceType="SingleEnum", atlas="SingleEnum"),
+                              prototype = list(sliceType = dtiSliceType("Axial"),
                                            atlas = dtiAtlasName("Adult_168labels_8atlases_V1")))

--- a/man/isJobFinished.Rd
+++ b/man/isJobFinished.Rd
@@ -8,7 +8,8 @@
 \usage{
 isJobFinished(object, jobId = "character")
 
-\S4method{isJobFinished}{MriCloudR,character}(object, jobId = "character")
+\S4method{isJobFinished}{MriCloudR,character}(object,
+  jobId = "character")
 }
 \arguments{
 \item{object}{Object of class \code{\link{MriCloudR-class}}.}


### PR DESCRIPTION
Fixing this for R3.6 (see note below)
`
In the definition of an S4 class, prototype elements are checked against the slots of the class, with giving a prototype for an undefined slot now being an error.
`